### PR TITLE
issue fix:  missing ED paid amounts

### DIFF
--- a/models/final/medical_claim.sql
+++ b/models/final/medical_claim.sql
@@ -1,13 +1,5 @@
-select * from {{ ref('carrier_claim')}}
-union all
-select * from {{ ref('dme_claim')}}
-union all
-select * from {{ ref('home_health_claim')}}
-union all
-select * from {{ ref('hospice_claim')}}
-union all
-select * from {{ ref('inpatient_claim')}}
-union all
-select * from {{ ref('outpatient_claim')}}
-union all
-select * from {{ ref('snf_claim')}}
+{{ dbt_utils.union_relations(
+    relations=[ref('carrier_claim'), ref('dme_claim'), ref('home_health_claim'), ref('hospice_claim')
+        , ref('inpatient_claim'), ref('outpatient_claim'), ref('snf_claim')],
+    exclude=["_DBT_SOURCE_RELATION"]
+) }}

--- a/models/intermediate/outpatient_claim.sql
+++ b/models/intermediate/outpatient_claim.sql
@@ -61,15 +61,15 @@ select
     , cast(b.org_npi_num as {{ dbt.type_string() }} ) as billing_npi
     , cast(b.srvc_loc_npi_num as {{ dbt.type_string() }} ) as facility_npi
     , date(NULL) as paid_date
+    , coalesce(
+            p.paid_amount
+            , cast(0 as {{ dbt.type_numeric() }})
+      ) as paid_amount
     , cast(NULL as {{ dbt.type_numeric() }}) as allowed_amount
     , p.charge_amount as charge_amount
     , cast(null as {{ dbt.type_numeric() }}) as coinsurance_amount
     , cast(null as {{ dbt.type_numeric() }}) as copayment_amount
     , cast(null as {{ dbt.type_numeric() }}) as deductible_amount
-    , coalesce(
-            p.paid_amount
-            , cast(0 as {{ dbt.type_numeric() }})
-      ) as paid_amount
     , p.total_cost_amount as total_cost_amount
     , 'icd-10-cm' as diagnosis_code_type
     , cast(b.prncpal_dgns_cd as {{ dbt.type_string() }} ) as diagnosis_code_1


### PR DESCRIPTION
## Describe your changes
Please include a summary of any changes.
Identified a bug in the UNION of different claim types (inpatient, outpatient, hospice, etc).  The column order of outpatient differed from the rest of the claim types causing paid_amount to populated in deductible_amount in the final medical claim table.

Fixed the order of the outpatient column.  Also changed the syntax of the UNION to a dbt macro that will union tables correctly even if their column are not in the same order.

## How has this been tested?
Please describe the tests you ran to verify your changes.  Provide instructions or code to reproduce output.
- ran a query that sums ED paid amount by month.  Confirmed it was no longer  producing NULL paid amounts

## Reviewer focus
Please summarize the specific items you’d like the reviewer(s) to look into.
n/a

## Checklist before requesting a review
- [x]  (Optional) I have recorded a Loom performing a self-review of my code
- [x]  My code follows style guidelines
- [ ]  I have commented my code as necessary
- [ ]  (New models only) I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [x]  I have added at least one Github label to this PR

## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
https://www.loom.com/share/31a99ea407a040dcb20ec5bed116ea8e?sid=b772eb7a-f633-4389-b662-82d4ba5250ac